### PR TITLE
build(deps): Move to Debian 11, Clang 19 and CMake 3.31.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM debian:oldstable-20250630-slim@sha256:5f8413ae7cbe44b328a7268fdc373de015fcd99930c510a99716b83984b4b4d9 AS build
-COPY clang-18.apt /tmp
+COPY clang-19.apt /tmp
 ARG CMAKE_VERSION=3.31.8
 RUN set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends \
     ca-certificates gnupg git make patch python3 wget; \
-  cat /tmp/clang-18.apt >> /etc/apt/sources.list; \
+  cat /tmp/clang-19.apt >> /etc/apt/sources.list; \
   wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -; \
   apt-get update; \
-  apt-get install -y --no-install-recommends clang-18; \
+  apt-get install -y --no-install-recommends clang-19; \
   cd /; \
   case "$(dpkg --print-architecture)" in \
     amd64)   ARCH="x86_64";;\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:oldstable-20250630-slim@sha256:5f8413ae7cbe44b328a7268fdc373de015fcd99930c510a99716b83984b4b4d9 AS build
 COPY clang-18.apt /tmp
-ARG CMAKE_VERSION=3.31.7
+ARG CMAKE_VERSION=3.31.8
 RUN set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM debian:oldoldstable-20240612-slim@sha256:297126bdb5f6b3dd2ce43c87fcd67678f3b8b2ecbed94fb9f18bbccca522bcb1 AS build
+FROM debian:oldstable-20250630-slim@sha256:5f8413ae7cbe44b328a7268fdc373de015fcd99930c510a99716b83984b4b4d9 AS build
 COPY clang-18.apt /tmp
-ARG CMAKE_VERSION=3.30.2
+ARG CMAKE_VERSION=3.31.7
 RUN set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends \
@@ -17,4 +17,3 @@ RUN set -eux; \
   wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${ARCH}.tar.gz; \
   tar -xvf cmake-${CMAKE_VERSION}-linux-${ARCH}.tar.gz --strip-components=1 -C /usr/; \
   cmake --version
-

--- a/clang-18.apt
+++ b/clang-18.apt
@@ -1,4 +1,0 @@
-
-# Clang/LLVM
-deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye main
-deb-src http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye main

--- a/clang-18.apt
+++ b/clang-18.apt
@@ -1,7 +1,4 @@
 
 # Clang/LLVM
-deb http://apt.llvm.org/buster/ llvm-toolchain-buster main
-deb-src http://apt.llvm.org/buster/ llvm-toolchain-buster main
-# 18
-deb http://apt.llvm.org/buster/ llvm-toolchain-buster-18 main
-deb-src http://apt.llvm.org/buster/ llvm-toolchain-buster-18 main
+deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye main
+deb-src http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye main

--- a/clang-19.apt
+++ b/clang-19.apt
@@ -1,0 +1,7 @@
+
+# Clang/LLVM
+deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye main
+deb-src http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye main
+# 19 
+deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-19 main
+deb-src http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-19 main


### PR DESCRIPTION
`apt-get update` is no longer working with Debian 10 - https://github.com/atsign-foundation/noports/issues/2042

**- What I did**

* Bump Debian to 11
* Bump Clang to 19
* Bump CMake to 3.31.8

**- Description for the changelog**

build(deps): Move to Debian 11, Clang 19 and CMake 3.31.8