### PR TITLE
fix: Use oldoldstable apt repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 FROM debian:oldstable-20250721-slim@sha256:0f53c0e545b3628fcea7befab2c7d452e77fe2ae3f7194f39a76d520984d9016 AS build
+# 20250811 patch sources.list to use oldoldstable whilst we await Debian
+# image updates in DockerHub
+COPY oldoldstable.apt /tmp
 COPY clang-19.apt /tmp
 ARG CMAKE_VERSION=3.31.8
 RUN set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends \
     ca-certificates gnupg git make patch python3 wget; \
+  cat /tmp/oldoldstable.apt > /etc/apt/sources.list; \
   cat /tmp/clang-19.apt >> /etc/apt/sources.list; \
   wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -; \
   apt-get update; \

--- a/oldoldstable.apt
+++ b/oldoldstable.apt
@@ -1,0 +1,6 @@
+# deb http://snapshot.debian.org/archive/debian/20250630T000000Z oldstable main
+deb http://deb.debian.org/debian oldoldstable main
+# deb http://snapshot.debian.org/archive/debian-security/20250630T000000Z oldstable-security main
+deb http://deb.debian.org/debian-security oldoldstable-security main
+# deb http://snapshot.debian.org/archive/debian/20250630T000000Z oldstable-updates main
+deb http://deb.debian.org/debian oldoldstable-updates main


### PR DESCRIPTION
Fixes https://github.com/atsign-foundation/noports/issues/2079

**- What I did**

Added a new `/etc/apt/sources.list` to be copied into place and modified Dockerfile to do that

**- How I did it**

Based on local testing

**- How to verify it**

Do a new release

**- Description for the changelog**

fix: Use oldoldstable apt repo